### PR TITLE
Make specified pages for category and tag

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -12,16 +12,14 @@ class CategoryController extends Controller
      *
      * @param  \App\Category  $category
      * @return \Illuminate\Http\Response
-     * @version 2018-08-27  Added Category in return
+     * @version 2018-08-27  - Added Category in return
      * @version 2018-09-21  - Added default view
-     *                      - Pass through posts based on new Category::publishedPosts method   
+     *                      - Pass through posts based on new Category::publishedPosts method
+     * @version 2018-10-01  - Call upon category.index view first, then post.index and lastly core.category.index for default
      */
     public function show(Category $category)
     {
         $posts = $category->publishedPosts()->latest()->simplePaginate(config('custom.postsPerPage'));
-        return view()->first(['post.index', 'core.post.index'])->with('category', $category)->with('posts', $posts);
-
-        //$posts = $category->posts()->where('published', true)->where('published_at', '<', now())->latest()->simplePaginate(config('custom.postsPerPage'));
-        //return view('post.index')->with('posts', $posts)->with('category', $category);
+        return view()->first(['category.index', 'post.index', 'core.category.index'])->with('category', $category)->with('posts', $posts);
     }
 }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -12,10 +12,13 @@ class TagController extends Controller
      *
      * @param  \App\Tag  $tag
      * @return \Illuminate\Http\Response
+     * @version 2018-09-21  - Added default view
+     *                      - Pass through posts based on new Tag::publishedPosts method
+     * @version 2018-10-01  - Call upon tag.index view first, then post.index and lastly core.tag.index for default
      */
     public function show(Tag $tag)
     {
         $posts = $tag->publishedPosts()->latest()->simplePaginate(config('custom.postsPerPage'));
-        return view()->first(['post.index', 'core.post.index'])->with('tag', $tag)->with('posts', $posts);
+        return view()->first(['tag.index', 'post.index', 'core.tag.index'])->with('tag', $tag)->with('posts', $posts);
     }
 }

--- a/resources/views/core/category/index.blade.php
+++ b/resources/views/core/category/index.blade.php
@@ -2,12 +2,15 @@
 
 @section ('main')
 
+    <div class="admin-container">
+        <h3 class="admin-h3">{{ $category->name }}</h3>
+        <p>{{ $category->description }}</p>
+    </div>
+
     @foreach ($posts as $post)
         @includeFirst(['core.category._single', 'core.post._single'], ['post' => $post])
     @endforeach
 
     {{ $posts->links() }} 
-
-    @include ('core.search._create')
 
 @endsection

--- a/resources/views/core/post/_single.blade.php
+++ b/resources/views/core/post/_single.blade.php
@@ -1,0 +1,11 @@
+<div class="admin-container">
+    <h3 class="admin-h3">{{ $post->title }}</h3>
+    
+    <div>
+        <p>{!! $post->getSummary() !!}</p>
+    </div>
+
+    <div class="mt-5">
+        <a href="{{ $post->path() }}">Read on</a>
+    </div>
+</div>

--- a/resources/views/core/search/_create.blade.php
+++ b/resources/views/core/search/_create.blade.php
@@ -1,13 +1,13 @@
 <div class="admin-container">
-    <h3 class="admin-h3">Zoeken</h3>
+    <h3 class="admin-h3">Search</h3>
 
     <form method="POST" action="{{ route('search.store') }}">
         @csrf       
 
         <div class="mb-5">
-            <label for="term" class="text-grey-darker text-sm font-bold mb-2 block">Zoeken naar...</label>
+            <label for="term" class="text-grey-darker text-sm font-bold mb-2 block">Search for...</label>
             <input type="text" name="term" id="term" class="shadow w-full border rounded px-2 py-2 focus:shadow-inner" required value="{{ old('term') }}" />
-            <p class="form-info">Wordt een URL van gemaakt en toont op de voorpagina</p>
+            <p class="form-info">We'll search in title, summary and body for you.</p>
 
             @if ($errors->has('term'))
                 <div class="form-error">
@@ -17,7 +17,7 @@
         </div>
 
         <div class="mb-5 flex" style="justify-content: space-around">
-            <button type="submit" class="btn btn-blue">Zoeken</button>
+            <button type="submit" class="btn btn-blue">Search</button>
         </div>
     </form>
 </div>

--- a/resources/views/core/search/show.blade.php
+++ b/resources/views/core/search/show.blade.php
@@ -1,30 +1,25 @@
 @extends ('core.layout.app')
 
 @section ('main')
-<div class="admin-container">
-    <h3 class="admin-h3">Resultaten</h3>
 
-    <table class="w-full">
-        <tr class="border-b">
-            <th class="">Title</th>
-            <th class="hidden lg:table-cell">Summary</th>
-        </tr>
 
-        @forelse ($posts as $post)
-        <tr class="border-b border-grey-light hover:border-blue">
-            <td class="" >
-                <a href="{{ route('post.show', $post) }}">{{ $post->getLongTitle() }}</a>
-            </td>
+    <div class="admin-container">
+        <h3 class="admin-h3">Results</h3>
+        <p>You've searched for the term <strong>{{ $search->term }}</strong>. These are the results we found for you:</p>
+    </div>
 
-            <td class="hidden lg:table-cell">
-                {{ $post->getSummary() }}
-            </td>
-        </tr>
-        @empty
-        <tr class="border-b border-grey-light hover:border-blue">
-            <td colspan="2" >No results found</td>
-        </tr>
-        @endforelse
-    </table>
-</div>
+    @forelse ($posts as $post)
+        @includeFirst(['core.category._single', 'core.post._single'], ['post' => $post])
+    @empty
+        <div class="admin-container">
+            <h3 class="admin-h3">No results found</h3>
+            
+            <div>
+                <p>Searching for {{ $search->term }} apparently didn't yield any results. Why not try to search for something else?</p>
+            </div>
+
+        </div>
+    @endforelse
+
+    @include ('core.search._create')
 @endsection

--- a/resources/views/core/tag/index.blade.php
+++ b/resources/views/core/tag/index.blade.php
@@ -1,0 +1,16 @@
+@extends ('core.layout.app')
+
+@section ('main')
+
+    <div class="admin-container">
+        <h3 class="admin-h3">{{ $tag->name }}</h3>
+        <p>{{ $tag->description }}</p>
+    </div>
+
+    @foreach ($posts as $post)
+        @includeFirst(['core.tag._single', 'core.post._single'], ['post' => $post])
+    @endforeach
+
+    {{ $posts->links() }} 
+
+@endsection


### PR DESCRIPTION
Instead of conditionally showing a category or tag name on the posts index page, extract single posts to the post._single view and create separate tag and category index pages. These index's will include the post._single view for each post, but will show their own details.