### PR TITLE
Added slug nullability

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -103,7 +103,7 @@ class PostController extends Controller
             'title' => ['nullable', 'min:3', 'max:255'],
             'longTitle' => 'nullable|min:3|max:255',
             'slug' => [
-                'required',
+                'nullable',
                 Rule::unique('posts')->ignore($post->id),
             ],
             'summary' => 'nullable',


### PR DESCRIPTION
On post update, make slug nullable. Should already have been, but somehow got copied over from the store-route validation.