### PR TITLE
More nullability improvements

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -100,6 +100,7 @@ class PostController extends Controller
     public function update(Request $request, Post $post)
     {
         $data = $request->validate([
+            'user_id' => 'nullable',
             'title' => ['nullable', 'min:3', 'max:255'],
             'longTitle' => 'nullable|min:3|max:255',
             'slug' => [

--- a/app/Post.php
+++ b/app/Post.php
@@ -42,7 +42,7 @@ class Post extends Model implements Feedable
     /** 
      * Set the custom published at attribute
      * 
-     * @param string    $date
+     * @param string    $datetime
      */
     public function setPublishedAtAttribute($datetime)
     {
@@ -53,12 +53,22 @@ class Post extends Model implements Feedable
         }
     }
 
+    /**
+     * Process a posts data on create or update.
+     * 
+     * @param   array   $data
+     * @return  array   Processed $data
+     * @version 20181002    - Only update user_id if there isn't one
+     *                      - Only update slug if there is a title
+     */
     public static function processData($data) {
         // A post is always linked to the currently authenticated user
-        $data['user_id'] = auth()->id();
+        if (!isset($data['user_id'])) {
+            $data['user_id'] = auth()->id();
+        }        
 
         // If there isn't a slug (and therefor it's a new post) a slug should be created
-        if (!isset($data['slug'])) {
+        if (!isset($data['slug']) && isset($data['title'])) {
             $data['slug'] = static::createSlug($data['title']);
         }
 

--- a/resources/views/core/admin/post/edit.blade.php
+++ b/resources/views/core/admin/post/edit.blade.php
@@ -10,6 +10,8 @@
     @csrf
     @method ('PATCH')
 
+    <input type="hidden" id="user_id" name="user_id" value="{{ $post->user_id }}" />
+
     <div class="admin-container">
         <h3 class="admin-h3">Edit post</h3>
 


### PR DESCRIPTION
For user_id on update posts, to avoid post authors being overwritten at a post update by another user.