### PR TITLE
Multiple changes set on by the nullability changes

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -60,11 +60,8 @@ class PostController extends Controller
 
         $data = Post::processData($data);
 
-        $post = Post::create($data);
-
-        $post->tags()->sync(request('tags'));
-        $post->categories()->sync(request('categories'));
-
+        $post = Post::create($data)->sync($request);
+        
         return redirect($post->path())->with("success", "Post posted");
     }
 
@@ -120,9 +117,7 @@ class PostController extends Controller
         $data = Post::processData($data);
 
         $post->update($data);
-
-        $post->tags()->sync(request('tags'));
-        $post->categories()->sync(request('categories'));
+        $post->sync($request);       
 
         return redirect(route('admin.post.edit', $post))->with("success", "Post updated");
     }

--- a/app/Post.php
+++ b/app/Post.php
@@ -82,6 +82,27 @@ class Post extends Model implements Feedable
     }
 
     /**
+     * Sync a posts related tags and categories if needed
+     * 
+     * @param   Illuminate\Http\Request $request
+     * @version 20181002
+     */
+    public function sync($request)
+    {
+        // If the request has tags, sync them.
+        if ($request->has('tags')) {
+            $post->tags()->sync($request->tags);
+        }
+
+        // If the request has categories, sync them.
+        if ($request->has('categories')) {
+            $post->categories()->sync($request->categories);
+        }
+
+        return $this;
+    }
+
+    /**
      * Define the relationship between posts and comments. 
      * 
      * Each post can have many comments, but each comment

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -4,8 +4,11 @@ use Faker\Generator as Faker;
 use Illuminate\Support\Carbon;
 
 $factory->define(App\Post::class, function (Faker $faker) {
+
+    $title = $faker->word . " " . $faker->word;
+
     return [
-        'title' => $faker->word,
+        'title' => $title,
         'longTitle' => $faker->sentence,
         'slug' => $faker->word,
         'summary' => $faker->paragraph,

--- a/resources/views/core/admin/post/edit.blade.php
+++ b/resources/views/core/admin/post/edit.blade.php
@@ -193,8 +193,24 @@
         <div class="mb-5 flex" style="justify-content: space-around">
             <button type="submit" class="btn btn-blue">Save</button>
             <button type="reset" class="btn btn-grey">Reset</button>
-            <a href="{{ route('admin.post.destroy', $post) }}" onclick="return confirm('Are you sure you want to delete this post? It cannot be undone!');" class="btn btn-red">Delete</a>
         </div>
     </div>
+</form>
+
+<form method="POST" action="{{ route('admin.post.destroy', $post) }}" >
+    @csrf
+    @method ('DELETE')
+
+    <div class="admin-container">
+        <h3 class="admin-h3">Delete post</h3>
+
+        <p>
+            If you use this button, you will completely delete a post from all records. It will vanish into the void that is called nothing. It can NOT be undone! If there is even the slightest chance you will want to keep whatever you've written, just unpublish it.
+        </p>
+
+        <div class="mb-5">
+            <button type="submit" class="btn btn-red" onclick="return confirm('Are you sure you want to delete this post? It cannot be undone!');">Delete</button>
+        </div>
+    </div>    
 </form>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,7 +37,7 @@ Route::group(['prefix' => 'admin'], function () {
     Route::post('post/', 'Admin\PostController@store')->name('admin.post.store');
     Route::get('post/{post}/edit', 'Admin\PostController@edit')->name('admin.post.edit');
     Route::patch('post/{post}', 'Admin\PostController@update')->name('admin.post.update');
-    Route::get('post/{post}/delete', 'Admin\PostController@destroy')->name('admin.post.destroy');
+    Route::delete('post/{post}/delete', 'Admin\PostController@destroy')->name('admin.post.destroy');
     Route::get('post/{post}', 'Admin\PostController@show')->name('admin.post.show');
 
     Route::get('comment', 'Admin\CommentController@index')->name('admin.comment.index');


### PR DESCRIPTION
- Moving delete route to delete request (instead of get)
- In post.edit, move delete button to own form
- Posts factory to extend title to avoid validation failure (and adjusted tests accordingly)
- Add a post->sync method for tags and category syncing