### PR TITLE
Changes to accomodate formresponse notification by e-mail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM_ADDRESS="noreply@blog.local"
 MAIL_FROM_NAME="Local Blog"
+MAIL_ADMIN_ADDRESS="admin@blog.local"
 
 FEED_URL="posts.rss"
 FEED_TITLE="Post feed title"

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,6 +26,7 @@ class Kernel extends ConsoleKernel
     {
         // $schedule->command('inspire')
         //          ->hourly();
+        $schedule->command('queue:work --stop-when-empty')->everyMinute();
     }
 
     /**

--- a/app/Form.php
+++ b/app/Form.php
@@ -46,6 +46,17 @@ class Form extends Model
         return $this->hasMany(FormField::class)->orderBy('id', 'ASC');
     }
 
+    public function hasMailField()
+    {        
+        foreach ($this->fields as $field) {
+            if ($field->type == "email") {
+                return $field->elementId;
+            }
+        }
+        
+        return null;
+    }
+
     /**
      * Define the relationship between a form and its responses. 
      * 

--- a/app/FormResponse.php
+++ b/app/FormResponse.php
@@ -3,10 +3,34 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\NewFormResponse;
+use App\Mail\NewFormResponseCopy;
+use Illuminate\Support\Facades\Log;
 
 class FormResponse extends Model
 {
-    protected $fillable = ['form_id', 'content'];
+    protected $fillable = ['form_id', 'email', 'content'];
+
+    protected static function boot()
+    {
+        parent::boot();
+        
+        static::created(function ($formResponse) {
+            Log::info("Queueing a new FormResponse mail to ".config('custom.adminEmailAddress')." with the following details: ", $formResponse->toArray());
+            Mail::to(config('custom.adminEmailAddress'))->queue(new NewFormResponse($formResponse));
+
+            if ($formResponse->email !== null) {
+                Log::info("Queueing a new FormResponseCopy mail to ".$formResponse->email." with the following details: ", $formResponse->toArray());
+                Mail::to($formResponse->email)->queue(new NewFormResponseCopy($formResponse));
+            }
+        });
+    }
+
+    public function getContent()
+    {
+        return json_decode($this->content, true);
+    }
 
     /**
      * Define the relationship between a FormResponse and its Form. 

--- a/app/Http/Controllers/Admin/FormController.php
+++ b/app/Http/Controllers/Admin/FormController.php
@@ -62,7 +62,7 @@ class FormController extends Controller
                 FormField::create([
                     'form_id' => $form->id,
                     'input' => $request->input[$i],
-                    'type' => $request->type[$i],
+                    'type' => ($request->input[$i] == "input" ? $request->type[$i] : null),
                     'name' => $request->elementName[$i],
                     'elementId' => str_slug($request->elementName[$i]),
                     'class' => $request->class[$i],

--- a/app/Http/Controllers/FormResponseController.php
+++ b/app/Http/Controllers/FormResponseController.php
@@ -16,8 +16,11 @@ class FormResponseController extends Controller
      */
     public function store(Request $request, Form $form)
     {
+        $mailfield = $form->hasMailField();
+
         $formResponse = FormResponse::create([
             'form_id' => $form->id,
+            'email' => ($mailfield) ? $request->$mailfield : $mailfield,
             'content' => json_encode($request->except('_token')),
         ]);
         

--- a/app/Mail/NewFormResponse.php
+++ b/app/Mail/NewFormResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\FormResponse;
+
+class NewFormResponse extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $formResponse;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($formResponse)
+    {
+        $this->formResponse = $formResponse;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->subject("New form response at ".config('app.name'))->markdown('mail.newFormresponse');
+    }
+}

--- a/app/Mail/NewFormResponseCopy.php
+++ b/app/Mail/NewFormResponseCopy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use App\FormResponse;
+
+class NewFormResponseCopy extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $formResponse;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($formResponse)
+    {
+        $this->formResponse = $formResponse;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->subject("Your form entry at ".config('app.name'))->markdown('mail.newFormResponseCopy');
+    }
+}

--- a/app/Notifications/NewFormResponse.php
+++ b/app/Notifications/NewFormResponse.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Log;
+
+class NewFormResponse extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected $formResponse;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($formResponse)
+    {
+        $this->formResponse = $formResponse;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)->markdown('mail.newFormresponse');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/config/custom.php
+++ b/config/custom.php
@@ -25,4 +25,6 @@ return [
     'tinyMCEStyle' => env('TINYMCE_STYLE', 'regular'),
 
     'tinyMCEAPIkey' => env('TINYMCE_APIKEY', false),
+
+    'adminEmailAddress' => env('MAIL_ADMIN_ADDRESS', false),
 ];

--- a/database/migrations/2019_01_31_142021_add_email_to_formresponse.php
+++ b/database/migrations/2019_01_31_142021_add_email_to_formresponse.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEmailToFormresponse extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('form_responses', function (Blueprint $table) {
+            $table->string('email')->after('form_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('form_responses', function (Blueprint $table) {
+            $table->dropColumn('email');
+        });
+    }
+}

--- a/resources/views/mail/newFormResponseCopy.blade.php
+++ b/resources/views/mail/newFormResponseCopy.blade.php
@@ -1,0 +1,14 @@
+@component('mail::message')
+# New Form Response
+
+Thank you for using the website {{ config('app.url') }}. These are the details you left us.
+
+@component('mail::panel')
+    @foreach ($formResponse->getContent() as $key => $value)
+        {{ $key }}: {{ $value }}<br />
+    @endforeach
+@endcomponent
+
+Kind regards,<br>
+{{ config('app.name') }}
+@endcomponent

--- a/resources/views/mail/newFormresponse.blade.php
+++ b/resources/views/mail/newFormresponse.blade.php
@@ -1,0 +1,18 @@
+@component('mail::message')
+# New Form Response
+
+A new response was left using your form **{{ $formResponse->form->name }}**
+
+@component('mail::panel')
+    @foreach ($formResponse->getContent() as $key => $value)
+        {{ $key }}: {{ $value }}<br />
+    @endforeach
+@endcomponent
+
+@component('mail::button', ['url' => route('admin.form.index')."#".$formResponse->form->name."-".$formResponse->form->id])
+View in dashboard
+@endcomponent
+
+Thanks,<br>
+{{ config('app.name') }}
+@endcomponent


### PR DESCRIPTION
- Add admin email address in .env(.example)
- Add function to find Forms mailfield
- Add column email to FormResponse table to store email address of responsee
- Mail FormResponse to both admin and responsee
- Add job to Kernel processing jobs every minute when cron calls the scheduler.

**Don't forget to migrate and add MAIL_ADMIN_ADDRESS to .env.**