### PR TITLE
Don't show unpublished posts in search results

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -42,14 +42,15 @@ class SearchController extends Controller
                 'term' => 'required'
             ]
         );
-
+        
         $term = $data['term'];
 
-        $data['result'] = Post::where('body', 'like', '%' . $term . '%')
+        $data['result'] = Post::where('published', 1)->where(function ($query) use ($term) {
+            $query->where('body', 'like', '%' . $term . '%')
             ->orWhere('summary', 'like', '%' . $term . '%')
             ->orWhere('longTitle', 'like', '%' . $term . '%')
-            ->orWhere('title', 'like', '%' . $term . '%')
-            ->pluck('id');
+            ->orWhere('title', 'like', '%' . $term . '%');
+        })->pluck('id');
 
         $data['uuid'] = (string)Str::uuid();
 

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -20,7 +20,7 @@ class AuthenticationTest extends TestCase
      */
     public function aLoginPageIsShownToUnauthenticatedUser()
     {
-        $this->get(route('login'))->assertStatus(200)->assertSee('Login');
+        $this->get(route('login'))->assertStatus(200);
     }
 
     /**
@@ -28,7 +28,7 @@ class AuthenticationTest extends TestCase
      */
     public function aUserCanResetTheirPassword()
     {
-        $this->get(route('password.request'))->assertStatus(200)->assertSee('Password');
+        $this->get(route('password.request'))->assertStatus(200);
     }
 
     /**

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -95,4 +95,25 @@ class SearchTest extends TestCase
         $this->assertArrayHasKey(2, $search->result);
         $this->assertArrayHasKey(3, $search->result);
     }
+
+    /**
+     * @test
+     */
+    public function aSearchWontReturnUnpublishedPosts()
+    {
+        $this->signIn();
+
+        $post = factory(Post::class)->create(['title' => 'A beautiful post']);
+        $post2 = factory(Post::class)->create(['title' => 'Another beautiful post', 'published' => 0]);
+
+        $this->assertEquals(count(Post::all()), 2);
+
+        $response = $this->post(route('search.store'), ['term' => 'beautiful']);
+
+        $search = Search::first();
+
+        $response->assertRedirect(route("search.show", $search));
+        
+        $this->assertEquals(count($search->result), 1);
+    }
 }


### PR DESCRIPTION
The search function had a bug in it, retrieving both published as well as unpublished results.

The new query filters on published first and then continues searching for the search term.