### PR TITLE
Bugfix Str::replace

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -74,7 +74,7 @@ class Post extends Model implements Feedable
 
             $form = Form::find($temptext[2]);
 
-            $text = Str::replace_first("||FORM||{$temptext[2]}||", $form->toHTML(), $text);            
+            $text = Str::replaceFirst("||FORM||{$temptext[2]}||", $form->toHTML(), $text);            
         }
 
         return $text;

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -53,7 +53,7 @@ class Setting extends Model
 
     public static function updateSingle($code, $value)
     {
-        $code = Str::replace('_', '.', $code);
+        $code = str_replace('_', '.', $code);
 
         return DB::table('settings')
         ->where('code', $code)


### PR DESCRIPTION
Str::replace doesn't actually exists. Strangely enough.

str_replace does, so lets use that instead.