### PR TITLE
Translate form responses

### DIFF
--- a/app/Http/Controllers/Admin/FormController.php
+++ b/app/Http/Controllers/Admin/FormController.php
@@ -22,9 +22,6 @@ class FormController extends Controller
      */
     public function index()
     {
-        // $forms = Form::all();
-        // $responses = FormResponse::all();
-
         return view('core.admin.form.index')->with('forms', Form::all());
     }
 

--- a/app/Http/Controllers/FormResponseController.php
+++ b/app/Http/Controllers/FormResponseController.php
@@ -26,15 +26,15 @@ class FormResponseController extends Controller
         $formResponse = FormResponse::create([
             'form_id' => $form->id,
             'email' => ($mailfield) ? $request->$mailfield : $mailfield,
-            'content' => json_encode($request->except('_token')),
+            'content' => json_encode($request->except(['_token', 'recaptcha_response'])),
         ]);
         
         if ($formResponse) {
-            $request->session()->flash('success', 'Form submission successful. Thank you!');
+            $request->session()->flash('success', \Setting::get('form.thanksForSubmission'));
             return redirect()->back();
         }
 
-        $request->session()->flash('error', 'Form submission failed. Please try again.');
+        $request->session()->flash('error', \Setting::get('form.submissionError'));
         return redirect()->back();
     }
 }

--- a/app/Mail/NewFormResponse.php
+++ b/app/Mail/NewFormResponse.php
@@ -31,6 +31,6 @@ class NewFormResponse extends Mailable
      */
     public function build()
     {
-        return $this->subject("New form response at ".config('app.name'))->markdown('mail.newFormresponse');
+        return $this->subject( \__("Somebody used your form at")." ".config('app.name'))->markdown('mail.newFormresponse');
     }
 }

--- a/app/Mail/NewFormResponseCopy.php
+++ b/app/Mail/NewFormResponseCopy.php
@@ -31,6 +31,6 @@ class NewFormResponseCopy extends Mailable
      */
     public function build()
     {
-        return $this->subject("Your form entry at ".config('app.name'))->markdown('mail.newFormResponseCopy');
+        return $this->subject( \__("Your form entry at")." ".config('app.name'))->markdown('mail.newFormResponseCopy');
     }
 }

--- a/database/seeds/SettingSeeder.php
+++ b/database/seeds/SettingSeeder.php
@@ -204,6 +204,26 @@ class SettingSeeder extends Seeder
             'hidden' => '0',
         ];
 
+        $settings[] = [
+            'code' => 'form.thanksForSubmission',
+            'type' => 'TEXT',
+            'label' => __("Form thank you"),
+            'description' => __("The message shown to the visitor when a form was successfully entered."),
+            'value' => null,
+            'category' => 'form',
+            'hidden' => '0',
+        ];
+
+        $settings[] = [
+            'code' => 'form.submissionError',
+            'type' => 'TEXT',
+            'label' => __("Form error"),
+            'description' => __("The message shown to the visitor when a form didn't save successfully."),
+            'value' => null,
+            'category' => 'form',
+            'hidden' => '0',
+        ];
+
         foreach ($settings as $setting) {
             try {
                 Setting::create($setting);

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -85,6 +85,7 @@
 
 
     "Send": "Verzenden",
+    "Form": "Formulier",
     "Forms": "Formulieren",
     "Create new form": "Nieuw formulier maken",
     "Action": "Doelbestemming",
@@ -169,5 +170,13 @@
     "Sets the default type to either post or page.": "Selecteert het standaard type (artikel of pagina) bij het aanmaken van een nieuw item.",
 
     "Blog URL": "Blog URL",
-    "At what URL is the blogpost-index available.": "Op welke pagina/URL wordt het blog getoond?"
+    "At what URL is the blogpost-index available.": "Op welke pagina/URL wordt het blog getoond?",
+
+    "New Form Response": "Formulier ingevuld",
+    "Thank you for using the form on the website. These are the details you left us.": "Bedankt voor het invullen van het formulier op de webiste. Dit zijn de gegevens die je hebt ingevuld.",
+    "Kind regards": "Vriendelijke groet",
+    "Your form entry at": "Je ingevulde formulier van",
+    "Somebody used your form at": "Formulier ingevuld op",
+    "One of your forms was used at your website.": "Een van je formulieren op de website is ingevuld.",
+    "View in dashboard": "Bekijk online"
 }

--- a/resources/views/core/admin/form/index.blade.php
+++ b/resources/views/core/admin/form/index.blade.php
@@ -63,7 +63,9 @@
             </div>
             <div class="flex-1 cat-desc mr-2">
                 @foreach (json_decode($response->content) as $field => $content)
-                    <strong>{{ $field }}</strong>: {{ $content }}<br />
+                    @if ($field !== "recaptcha_response")
+                        <strong>{{ $field }}</strong>: {{ $content }}<br />
+                    @endif
                 @endforeach
             </div>
             <div class="cat-actions">

--- a/resources/views/mail/newFormResponseCopy.blade.php
+++ b/resources/views/mail/newFormResponseCopy.blade.php
@@ -1,14 +1,14 @@
 @component('mail::message')
-# New Form Response
+# @lang("New Form Response")
 
-Thank you for using the website {{ config('app.url') }}. These are the details you left us.
+@lang("Thank you for using the form on the website. These are the details you left us.")
 
 @component('mail::panel')
     @foreach ($formResponse->getContent() as $key => $value)
-        {{ $key }}: {{ $value }}<br />
+        **{{ ucfirst($key) }}**: {{ $value }}<br />
     @endforeach
 @endcomponent
 
-Kind regards,<br>
+@lang("Kind regards"),<br>
 {{ config('app.name') }}
 @endcomponent

--- a/resources/views/mail/newFormresponse.blade.php
+++ b/resources/views/mail/newFormresponse.blade.php
@@ -1,18 +1,19 @@
 @component('mail::message')
-# New Form Response
+# @lang("New Form Response")
 
-A new response was left using your form **{{ $formResponse->form->name }}**
+@lang("One of your forms was used at your website.")
 
 @component('mail::panel')
+        **@lang("Form")**: {{ $formResponse->form->name }}<br />
     @foreach ($formResponse->getContent() as $key => $value)
-        {{ $key }}: {{ $value }}<br />
+        **{{ ucfirst($key) }}**: {{ $value }}<br />
     @endforeach
 @endcomponent
 
 @component('mail::button', ['url' => route('admin.form.index')."#".$formResponse->form->name."-".$formResponse->form->id])
-View in dashboard
+    @lang("View in dashboard")
 @endcomponent
 
-Thanks,<br>
+@lang("Kind regards"),<br>
 {{ config('app.name') }}
 @endcomponent


### PR DESCRIPTION
FormResponse emails were hardcoded in english. With this commit, all language strings related to FormResponses are translateable.