### PR TITLE
Remove foreign key constraint

### DIFF
--- a/database/migrations/2019_03_11_205022_create_meta_user_pivot_table.php
+++ b/database/migrations/2019_03_11_205022_create_meta_user_pivot_table.php
@@ -20,9 +20,6 @@ class CreateMetaUserPivotTable extends Migration
             $table->timestamps();
 
             $table->unique(['meta_id', 'user_id']);
-
-            $table->foreign('meta_id')->references('id')->on('metas')->onDelete('cascade');
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 


### PR DESCRIPTION
For some reason, the foreign key constraint for the meta information fails.

TODO: manually remove pivot records when removing either users or meta information