### PR TITLE
Bugfix wordcount

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -425,7 +425,7 @@ class Post extends Model implements Feedable
      */
     public function words()
     {
-        return Str::word_count(strip_tags($this->body));
+        return Str::words(strip_tags($this->body));
     }
 
     /**


### PR DESCRIPTION
Fixes bug where Post->words() uses a non-existing Str::word_count. Instead, use Str::words.