### PR TITLE
Bugfix for update meta-code

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -58,7 +58,7 @@ class LoginController extends Controller
      */
     protected function authenticated(Request $request, $user)
     {
-        $user->updateMeta('last_login', Carbon::now());
+        $user->updateMeta('last-login', Carbon::now());
         
         return redirect()->intended($user->home());
     }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -76,7 +76,7 @@ class RegisterController extends Controller
 
         // Always add the first user as Admin
         if ($user && User::all()->count() == 1) {
-            $user->updateMeta('level', 'admin');
+            $user->updateMeta('access-level', 'admin');
         }
 
         return $user;

--- a/app/User.php
+++ b/app/User.php
@@ -76,7 +76,7 @@ class User extends Authenticatable
 
     public function level()
     {
-        return $this->meta('level') ?? 'user';   
+        return $this->meta('access-level') ?? 'user';   
     }
 
     public function meta($code = null)

--- a/database/seeds/MetaSeeder.php
+++ b/database/seeds/MetaSeeder.php
@@ -13,13 +13,13 @@ class MetaSeeder extends Seeder
     public function run()
     {
         $metas[] = [
-            'code' => 'level',
+            'code' => 'access-level',
             'label' => 'Access level',
             'description' => __("Access level for the user."),
         ];
 
         $metas[] = [
-            'code' => 'last_login',
+            'code' => 'last-login',
             'label' => 'Last Login',
             'description' => __("Last time this user successfully logged in to the application."),
             'updateable' => false,
@@ -33,11 +33,11 @@ class MetaSeeder extends Seeder
             }
         }
 
-        $meta = Meta::where('code', 'level')->first();
+        $meta = Meta::where('code', 'access-level')->first();
 
         if ($meta && $meta->using('admin')->count() == 0) {
             try {
-                \App\User::first()->updateMeta('level', 'admin');
+                \App\User::first()->updateMeta('access-level', 'admin');
             } catch (Exception $e) {
                 // do nothing
             }

--- a/resources/views/core/admin/user/index.blade.php
+++ b/resources/views/core/admin/user/index.blade.php
@@ -21,7 +21,7 @@
             <td class="table-cell" >{{ $user->name }}</td>
             <td class="hidden lg:table-cell">{{ $user->email }}</td>
             <td class="hidden lg:table-cell">{{ $user->created_at->toFormattedDateString() }}</td>
-            <td class="hidden lg:table-cell">{{ $user->meta('last_login') }}</td>
+            <td class="hidden lg:table-cell">{{ $user->meta('last-login') }}</td>
             <td class="hidden lg:table-cell">{{ $user->level() }}</td>
             <td class="table-cell">
                 <a href="{{ route('admin.user.edit', $user) }}" class="no-underline">

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -24,7 +24,7 @@ class UserTest extends TestCase
         }
 
         $admin = factory(User::class)->create();
-        $meta = factory(Meta::class)->create(['key' => 'level']);
+        $meta = factory(Meta::class)->create(['key' => 'access-level']);
         $admin->updateMeta($meta->key, 'Admin');
 
         $this->signIn($admin);
@@ -60,7 +60,7 @@ class UserTest extends TestCase
     public function aUserCanBeEdited()
     {
         $admin = factory(User::class)->create();
-        $meta = factory(Meta::class)->create(['key' => 'level']);
+        $meta = factory(Meta::class)->create(['key' => 'access-level']);
         $admin->updateMeta($meta->key, 'Admin');
 
         $this->signIn($admin);
@@ -122,10 +122,10 @@ class UserTest extends TestCase
      */
     public function metadataDefinesModeratorLevel() {
         $user = factory(User::class)->create();
-        $meta = factory(Meta::class)->create(['key' => 'level']);
+        $meta = factory(Meta::class)->create(['key' => 'access-level']);
         $user->updateMeta($meta->key, 'Admin');
 
-        $this->assertEquals($user->meta('level'), 'Admin');
+        $this->assertEquals($user->meta('access-level'), 'Admin');
         $this->assertEquals($user->isAdmin(), true);
         $this->assertEquals($user->canModerate(), true);
     }
@@ -137,7 +137,7 @@ class UserTest extends TestCase
     {
         $user = factory(User::class)->create();
 
-        $this->assertEquals($user->meta('level'), null);
+        $this->assertEquals($user->meta( 'access-level'), null);
         $this->assertEquals($user->canModerate(), false);
     }
 }


### PR DESCRIPTION
When saving a new meta, the code is automatically set to a sluggified label in the Meta's boot method.

This works fine, but conflicts with the MetaSeeder as that wasn't updated to the new boot yet.

This commit fixes that. It means that all references to 'level' and 'last_login' are updated to 'access-level' and 'last-login'.