### PR TITLE
Fix bug on missing meta error

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -60,6 +60,6 @@ class LoginController extends Controller
     {
         $user->updateMeta('last-login', Carbon::now());
         
-        return redirect()->intended($user->home());
+        return redirect(route('profile.show', $user));
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -95,7 +95,11 @@ class User extends Authenticatable
     public function updateMeta($code = null, $value = null)
     {
         if (!empty($code)) {
-            return $this->metas()->sync([Meta::where('code', $code)->first()->id => ['value' => $value] ], false);
+            $meta = Meta::where('code', $code)->first();
+
+            if ($meta) {
+                return $this->metas()->sync([$meta->id => ['value' => $value] ], false);
+            }
         }
 
         return false;


### PR DESCRIPTION
When updating a user's META information with a non-existing code, don't continue if there isn't any meta id available.

Also change the redirect route after login, just send it to profile.