### PR TITLE
TokenMismatchException handling

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,6 +12,7 @@ class VerifyCsrfToken extends Middleware
      * @var array
      */
     protected $except = [
-        //
+        'admin/logout',
+        'search'
     ];
 }


### PR DESCRIPTION
Exclude admin/logout and search routes from the tokenMIsmatchException handling.