### PR TITLE
Validation on admin.post.update

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -108,7 +108,7 @@ class PostController extends Controller
             'published_at_date' => 'nullable|date',
             'published_at_time' => 'nullable|date_format:"H:i"',
             'type' => 'nullable',
-            'use_hash' => 'required',
+            'use_hash' => 'nullable|boolean',
             'hash' => 'nullable',
         ]);
 


### PR DESCRIPTION
Make use_has a nullable boolean validation rule instead of required.

This allows for updates from the front end directly to the back end.