### PR TITLE
Add link list to TinyMCE

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -164,6 +164,11 @@ class Post extends Model implements Feedable
         return $this->getTitle();
     }
 
+    public static function getPages()
+    {
+        return self::where('type', 'page')->orderBy('published_at', 'DESC')->get();
+    }
+
     /**
      * Return a custom path attribute (internal linking)
      * 
@@ -172,6 +177,11 @@ class Post extends Model implements Feedable
     public function getPathAttribute()
     {
         return "/{$this->slug}";
+    }
+
+    public static function getPosts()
+    {
+        return self::where('type', 'post')->orderBy('published_at', 'DESC')->get();
     }
 
     /**

--- a/resources/views/core/layout/app.blade.php
+++ b/resources/views/core/layout/app.blade.php
@@ -62,6 +62,16 @@
             image_advtab: true,
             language_url : '{{ config('app.url') }}/js/languages/{{ config('app.locale') }}.js',
             language: '{{ config('app.locale') }}',
+            link_list: [
+                {title: '-- Pages --', value: '/'},
+            @foreach (App\Post::getPages() as $page)
+                {title: '{{ $page->getTitle() }}', value: '{{ $page->path() }}'},
+            @endforeach
+                {title: '-- Posts --', value: '/'},
+            @foreach (App\Post::getPosts() as $post)
+                {title: '{{ $post->getTitle() }}', value: '{{ $post->path() }}'},
+            @endforeach
+            ],
             plugins: 'advlist anchor autosave code fullscreen help hr image imagetools insertdatetime link lists media nonbreaking pagebreak preview print searchreplace table template textpattern toc visualblocks visualchars wordcount',
             relative_urls : false,
             templates: [


### PR DESCRIPTION
Adds a link list of all pages and posts to the TinyMCE editor. Using this feature, you can easily link between your posts and pages.