### PR TITLE
Fix error on installation

### DIFF
--- a/app/Setting.php
+++ b/app/Setting.php
@@ -53,7 +53,11 @@ class Setting extends Model
 
     public static function get($code)
     {
-        return self::whereCode($code)->first()->value ?? null;
+        try {
+            return self::whereCode($code)->first()->value ?? null;
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 
     public static function updateSingle($code, $value)


### PR DESCRIPTION
During the first composer install, the settings table isn't created yet. Setting::get('home.route') will throw an exception.

This commit catches Exceptions when settings are retrieved and returns null. It should fix an error in package:discover during installation.