### PR TITLE
Add extra logging to subscription notifications

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -503,7 +503,8 @@ class Post extends Model implements Feedable
     }
 
     /**
-     * @deprecated?
+     * Define relationship between post and subscriptions.
+     * Definitely NOT deprecated!
      */
     public function subscriptions()
     {


### PR DESCRIPTION
Some sites mentioned failed jobs. This commit adds some extra logging to the subscription notifications that are sent when a new comment is created.