### PR TITLE
Annoying type in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ DB_USERNAME=root
 DB_PASSWORD=
 
 # WARNING: If you use a separate authentication database, make sure
-# DB_AUTH_USER has SELECT rights to the DB_DATABASEDB_AUTH=false
-DB_AUTH=true
+# DB_AUTH_USER has SELECT rights to the DB_DATABASE
+DB_AUTH=false
 DB_AUTH_CONNECTION=mysql_auth
 DB_AUTH_HOST=127.0.0.1
 DB_AUTH_PORT=3306


### PR DESCRIPTION
Put DB_AUTH=false on new line.
Replace line DB_AUTH=true, as FALSE is a much more likely scenario in stand alone applications.