### PR TITLE
New API method to store posts

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -4,7 +4,11 @@ namespace App\Http\Controllers\Api;
 
 use App\Post;
 use App\Http\Controllers\Controller;
+use App\Rules\UniqueSlug;
+use Carbon\Carbon;
 use Illuminate\Http\Response;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class PostController extends Controller
 {
@@ -21,7 +25,7 @@ class PostController extends Controller
             'data' => $posts->limit($limit)->get(),
             'status' => Response::HTTP_OK,
             'count' => $posts->count(),
-        ]);
+        ], 200);
     }
 
     /**
@@ -30,9 +34,89 @@ class PostController extends Controller
      * @param  \App\Post  $post
      * @return \Illuminate\Http\Response
      */
-    public function show(Post $post)
+    public function show($postID)
     {
-        return response()->json(['data' => $post,
-            'status' => Response::HTTP_OK]);
+        if ($post = Post::find($postID)) {
+            return response()->json([
+                'result' => true,
+                'data' => ['post' => $post],
+                'status' => Response::HTTP_OK,
+            ], 200);
+        } else {
+            return response()->json([
+                'result' => false,
+                'status' => Response::HTTP_NOT_FOUND,
+            ], 404);
+        }
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $data = $request->except(['token', 'user']);
+
+        $validator = Validator::make($data, [
+            'title' => ['required', 'min:3', 'max:255', new UniqueSlug],
+            'longTitle' => 'nullable|min:3|max:255',
+            'summary' => 'nullable',
+            'body' => 'required|min:3',
+            'commentable' => 'nullable|boolean',
+            'featured' => 'nullable|boolean',
+            'featureimage' => 'nullable',
+            'published' => 'nullable|boolean',
+            'published_at_date' => 'nullable|date',
+            'published_at_time' => 'nullable|date_format:"H:i"',
+            'type' => 'nullable',
+            'use_hash' => 'nullable',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'result' => false,
+                'data' => ['errors' => $validator->errors()],
+                'status' => Response::HTTP_UNPROCESSABLE_ENTITY
+            ], 422);
+        }
+
+        $data['user_id'] = auth()->user()->id;
+        
+        if (!isset($data['commentable'])) {
+            $data['commentable'] = 0;
+        }
+
+        if (!isset($data['featured'])) {
+            $data['featured'] = 0;
+        }
+
+        if (!isset($data['published'])) {
+            $data['published'] = 1;
+        }
+
+        if (!isset($data['published_at_date'])) {
+            $data['published_at_date'] = Carbon::now()->toDateString();
+        }
+
+        if (!isset($data['published_at_time'])) {
+            $data['published_at_time'] = Carbon::now()->toTimeString();
+        }
+
+        if (!isset($data['use_hash'])) {
+            $data['use_hash'] = 0;
+        }
+
+        $data = Post::processData($data);
+
+        $post = Post::create($data)->sync($request);
+        
+        return response()->json([
+            'result' => true,
+            'data' => ['post' => $post->fresh()],
+            'status' => Response::HTTP_OK
+        ], 200);
     }
 }

--- a/app/Http/Controllers/Profile/UserController.php
+++ b/app/Http/Controllers/Profile/UserController.php
@@ -7,6 +7,7 @@ use App\Meta;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Hash;
 
 class UserController extends Controller
 {
@@ -64,6 +65,10 @@ class UserController extends Controller
             'email' => ['required', 'email', Rule::unique('users')->ignore($user->id)],
         ]);
 
+        if (isset($request->api_token) && !empty($request->api_token)) {
+            $data['api_token'] = Hash::make($request->api_token);
+        }
+        
         $user->update($data);
 
         foreach (Meta::all() as $meta) {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,5 +60,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'moderator' => Middleware\Moderator::class,
+        'apiauthentication' => Middleware\ApiAuthentication::class,
     ];
 }

--- a/app/Http/Middleware/ApiAuthentication.php
+++ b/app/Http/Middleware/ApiAuthentication.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+
+class ApiAuthentication
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $user = \App\User::where(['email' => request()->user])->first();
+        
+        if (!$user || !Hash::check(request()->token, $user->api_token)) {
+            return response()->json([
+                'result' => false,
+                'data' => ['errors' => 'unauthorised'],
+                'status' => Response::HTTP_FORBIDDEN
+            ], 403);
+        }
+        
+        Auth::onceUsingId($user->id);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -13,6 +13,7 @@ class VerifyCsrfToken extends Middleware
      */
     protected $except = [
         'admin/logout',
-        'search'
+        'search',
+        'api/*',
     ];
 }

--- a/app/User.php
+++ b/app/User.php
@@ -16,7 +16,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'name', 'email', 'password', 'api_token'
     ];
 
     /**

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,13 @@
 - On Media index page, style images
 - On Menu admin page, split pages and posts & provide visual feedback for published status
 
+## 1.6.1
+
+- Add ApiAuthentication middleware (needs Database Migration for new api_token column for user).
+- Add API method to store posts (needs ApiAuthentication).
+- Changes in API responses, they now always return (boolean) result, followed by (array) data.
+- Bugfix: APi method to show single post.
+
 ## 1.6.0
 
 - UPDATE TO LARAVEL 6.0

--- a/config/auth.php
+++ b/config/auth.php
@@ -44,6 +44,7 @@ return [
         'api' => [
             'driver' => 'token',
             'provider' => 'users',
+            'hash' => true,
         ],
     ],
 

--- a/database/migrations/2019_09_30_130051_add_api_token_to_users_table.php
+++ b/database/migrations/2019_09_30_130051_add_api_token_to_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddApiTokenToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('api_token', 80)->after('password')
+                        ->unique()
+                        ->nullable()
+                        ->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/resources/views/core/admin/profile/edit.blade.php
+++ b/resources/views/core/admin/profile/edit.blade.php
@@ -20,6 +20,12 @@
             <p class="form-info">@lang('User\'s email address. Used for logging in and sending messages.')</p>
         </div>
 
+        <div class="form-group">
+            <label class="form-label" for="api_token">@lang('API token')</label>
+            <input class="form-control" id="api_token" name="api_token" type="text" value="" />
+            <p class="form-info">@lang('User\'s api_token. Used for logging in via the API. Only enter something here if you want to CHANGE your current token.')</p>
+        </div>
+
         @foreach (App\Meta::where('updateable', true)->get() as $meta)
             @if ($meta->code !== "access-level")
             <div class="form-group">

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,3 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,8 +27,9 @@ App\Setting::routes();
  * API ROUTES
  */
 Route::group(['prefix' => 'api'], function () {
+    Route::post('posts/store', 'Api\PostController@store')->middleware('apiauthentication');
     Route::get('post/{limit?}', 'Api\PostController@index');
-    Route::get('post/{post}', 'Api\PostController@show');
+    Route::get('post/show/{post}', 'Api\PostController@show');
 });
 
 /**


### PR DESCRIPTION
## 1.6.1

- Add ApiAuthentication middleware (needs Database Migration for new api_token column for user).
- Add API method to store posts (needs ApiAuthentication).
- Changes in API responses, they now always return (boolean) result, followed by (array) data.
- Bugfix: APi method to show single post.