### PR TITLE
Swap newlines for br on API post store

### DIFF
--- a/app/Http/Controllers/Api/PostController.php
+++ b/app/Http/Controllers/Api/PostController.php
@@ -82,8 +82,6 @@ class PostController extends Controller
                 'status' => Response::HTTP_UNPROCESSABLE_ENTITY
             ], 422);
         }
-
-        $data['user_id'] = auth()->user()->id;
         
         if (!isset($data['commentable'])) {
             $data['commentable'] = 0;
@@ -111,6 +109,8 @@ class PostController extends Controller
 
         $data = Post::processData($data);
 
+        $data['body'] = "<p>".nl2br($data['body'])."</p>";
+        
         $post = Post::create($data)->sync($request);
         
         return response()->json([


### PR DESCRIPTION
- When storing a post using API, add HTML paragraph tags around body
- Also pass body through nl2br
- Remove setting of user_id in controller, as Post::processData takes care of that.