### PR TITLE
Remove meta-update

### DIFF
--- a/app/Http/Controllers/Profile/UserController.php
+++ b/app/Http/Controllers/Profile/UserController.php
@@ -68,14 +68,15 @@ class UserController extends Controller
         if (isset($request->api_token) && !empty($request->api_token)) {
             $data['api_token'] = Hash::make($request->api_token);
         }
-        
+
         $user->update($data);
 
-        foreach (Meta::all() as $meta) {
-            if ($meta->updateable) {
-                $user->updateMeta($meta->code, $request->{$meta->code});
-            }
-        }
+        // Turned off, as META information isn't available at this point. Should be fixed in future.
+        // foreach (Meta::all() as $meta) {
+        //     if ($meta->updateable) {
+        //         $user->updateMeta($meta->code, $request->{$meta->code});
+        //     }
+        // }
 
         return redirect(route('profile.show', $user))->with("success", "User updated");
     }


### PR DESCRIPTION
On Profile\UserController update, all meta information was updated on a save.

But, as the meta information is not availble in request at that point, it just removed all saved meta information.

This commit comments out the meta-update so that all currently stored information remains stored.