### PR TITLE
Add the ability to submit spam

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -13,11 +13,14 @@ class Comment extends Model
 {
     protected $fillable = ['post_id', 'name', 'emailaddress', 'body', 'ip', 'approved', 'notify'];
 
+    /**
+     * @version 20191108    Changed event from 'saved' to 'created', as the saved event is also triggered when model is updated.
+     */
     protected static function boot()
     {
         parent::boot();
         
-        static::saved(function ($comment) {
+        static::created(function ($comment) {
             Subscription::send($comment);
             
             Log::info("Sending a copy of new comment to Admin");

--- a/app/Http/Controllers/Admin/SubmitSpamController.php
+++ b/app/Http/Controllers/Admin/SubmitSpamController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Comment;
+use App\Libraries\Akismet;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+use App\Setting;
+
+class SubmitSpamController extends Controller
+{
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Comment $comment)
+    {
+        if (!empty(Setting::get('comment.akismet.key'))) {
+            $akismet = new Akismet($comment);
+
+            if ($akismet->validateKey()) {
+                $akismet->submitSpam();
+            }
+
+            $comment->update([
+                'approved' => 0
+            ]);
+
+            Log::info("Comment passed through to Akismet for spam reporting, this is the result:", [$akismet->getResponse()]);
+
+            return back()->with('success', 'The comment has been flagged as spam at Akismet');
+        }
+    }
+}

--- a/resources/views/core/admin/comment/index.blade.php
+++ b/resources/views/core/admin/comment/index.blade.php
@@ -25,7 +25,7 @@
                 </a>&nbsp;
 
                 <a class="btn-purple-text" href="{{ route('admin.comment.edit', $comment) }}">
-                    <i  data-feather="edit-3"></i>
+                    <i data-feather="edit-3"></i>
                 </a>&nbsp;
 
                 <form class="m-0" method="POST" action="{{ route('admin.comment.update', $comment) }}">
@@ -43,6 +43,12 @@
                     </button>
                     @endif
                 </form>&nbsp;
+
+                @if (!empty(\App\Setting::get('comment.akismet.key')))
+                <a class="btn-gray-text" href="{{ route('admin.comment.submitspam', $comment) }}">
+                    <i data-feather="flag"></i>
+                </a>&nbsp;
+                @endif
 
                 <form class="m-0" method="POST" onsubmit="return confirm('Are you sure?');" action="{{ route('admin.comment.destroy', $comment) }}">
                     @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ Route::group(['prefix' => 'admin'], function () {
 
     Route::get('comment', 'Admin\CommentController@index')->name('admin.comment.index');
     Route::get('comment/{comment}/edit', 'Admin\CommentController@edit')->name('admin.comment.edit');
+    Route::get('comment/{comment}/submitspam', 'Admin\SubmitSpamController@store')->name('admin.comment.submitspam');
     Route::patch('comment/{comment}', 'Admin\CommentController@update')->name('admin.comment.update');
     Route::delete('comment/{comment}', 'Admin\CommentController@destroy')->name('admin.comment.destroy');
 
@@ -104,7 +105,7 @@ Route::get('sitemap.xml', function() {
 });
 
 if($customClasses = App\Setting::get('custom.routeClasses')) {    
-    foreach (json_decode($customClasses) as $class) {
+    foreach (explode(",", $customClasses) as $class) {
         if (!empty($class)) {
             $class = 'App\\' . $class;
             $class::routes();


### PR DESCRIPTION
This commit adds the ability to submit spam from the admin panel.

If an Akismet key is available, it shows a flag on admin.comment.index.

Clicking the flag will submit the comment to Akismet and set the approved status to 0.

Also fixed a bug where an update on a comment will trigger a saved event, including the "new comment" flow.

Fixed a minor issue where the Custom class routes setting gives an error in the routes/web file when input is not as expected.