### PR TITLE
Fix memory error on busy blogs

### DIFF
--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -24,7 +24,7 @@ class PostController extends Controller
      */
     public function index()
     {
-        return view('core.admin.post.index')->with('posts', Post::with(['views', 'comments'])->get());
+        return view('core.admin.post.index')->with('posts', Post::with(['comments'])->get());
     }
 
     /**

--- a/resources/views/core/admin/post/edit.blade.php
+++ b/resources/views/core/admin/post/edit.blade.php
@@ -13,6 +13,12 @@
     <div class="admin-container">
         <h3 class="admin-h3 flex justify-between">
             @lang('Edit post')
+            <span class="font-normal">
+                @lang('Comments'): {{ $post->comments->count() }}
+            </span>
+            <span class="font-normal">
+                @lang('Views'): {{ $post->views->count() }}
+            </span>
             <span>
                 <a  class="no-underline inline-block btn-purple-text"
                     href="{{ route('admin.post.edit', $post) }}?action=duplicate"

--- a/resources/views/core/admin/post/index.blade.php
+++ b/resources/views/core/admin/post/index.blade.php
@@ -20,7 +20,6 @@
             <th class="table-cell">@lang('Title')</th>
             <th class="hidden lg:table-cell">@lang('Summary')</th>
             <th class="hidden lg:table-cell">@lang('Published at')</th>
-            <th class="hidden lg:table-cell">@lang('Views')</th>
             <th class="hidden lg:table-cell">@lang('Comments')</th>
             <th class="table-cell" colspan="2">@lang('Actions')</th>
         </tr>
@@ -32,7 +31,6 @@
             </td>
             <td class="hidden lg:table-cell">{!! $post->summary !!}</td>
             <td class="hidden lg:table-cell @if (!$post->isPublished()) bg-red-100 @endif">{{ $post->published_at->toFormattedDateString() }}</td>
-            <td class="hidden lg:table-cell">{{ $post->views->count() }}</td>
             <td class="hidden lg:table-cell">{{ $post->comments->count() }}</td>
             <td class="table-cell">
                 <a href="{{ route('admin.post.edit', $post) }}" class="btn-purple-text">
@@ -60,7 +58,6 @@
             <th class="table-cell">@lang('Title')</th>
             <th class="hidden lg:table-cell">@lang('Summary')</th>
             <th class="hidden lg:table-cell">@lang('Published at')</th>
-            <th class="hidden lg:table-cell">@lang('Views')</th>
             <th class="hidden lg:table-cell">@lang('Comments')</th>
             <th class="table-cell" colspan="2">@lang('Actions')</th>
         </tr>
@@ -81,7 +78,6 @@
                 </td>
                 <td class="hidden lg:table-cell">{!! $post->summary !!}</td>
                 <td class="hidden lg:table-cell @if (!$post->published) bg-red-100 @endif">{{ $post->published_at->toFormattedDateString() }}</td>
-                <td class="hidden lg:table-cell">{{ $post->views->count() }}</td>
                 <td class="hidden lg:table-cell">{{ $post->comments->count() }}</td>
                 <td class="table-cell">
                     <a href="{{ route('admin.post.edit', $post) }}" class="btn-purple-text">


### PR DESCRIPTION
When many posts have many views, the admin.post.index page runs into memory errors.

This commit removes the amount of views from the index page and moves it to admin.post.edit.