### PR TITLE
Add option to create custom RSS feed

### DIFF
--- a/app/Category.php
+++ b/app/Category.php
@@ -31,6 +31,22 @@ class Category extends CacheModel
         return \Purify::clean($description);
     }
 
+    /** 
+     * Get all items to post on custom RSS feed
+     * 
+     * @return Collection
+     */
+    public static function getFeedItems()
+    {
+        $posts = collect();
+
+        foreach (Setting::get('rss.customFeedCategories') as $category) {
+            $posts = $posts->merge(Category::whereSlug($category)->first()->publishedPosts()->whereType('post')->get());
+        }
+
+        return $posts->unique('id');
+    }
+
     public function setSlugAttribute($value)
     {
         $this->attributes['slug'] = Str::slug($value);

--- a/app/Libraries/Helpers.php
+++ b/app/Libraries/Helpers.php
@@ -6,3 +6,10 @@ if (!function_exists('is_current_url')) {
         return Request::path() == str_replace(config('app.url').'/', '', $url);
     }
 }
+
+if (!function_exists('setting')) {
+    function setting($setting)
+    {
+        return App\Setting::get($setting);
+    }
+}

--- a/app/Setting.php
+++ b/app/Setting.php
@@ -84,7 +84,13 @@ class Setting extends Model
     {
         return Cache::rememberForever('settings.'.$code, function () use ($code) {
             try {
-                return self::select('value')->whereCode($code)->first()->value ?? null;
+                $setting = self::whereCode($code)->first() ?? null;
+
+                if ($setting->type == 'ARRAY') {
+                    return json_decode($setting->value);
+                }
+
+                return $setting->value;
             } catch (\Exception $e) {
                 return null;
             }
@@ -103,7 +109,11 @@ class Setting extends Model
             $setting->value = json_encode(explode("\r\n", $value));
         }
 
-        Cache::put('settings.'.$code, $value);
+        Cache::put('settings.'.$code, $setting->value);
+
+        if ($setting->type == 'ARRAY') {
+            return Cache::put('settings.'.$code, json_decode($setting->value));
+        }
 
         return $setting->save();
     }

--- a/config/feed.php
+++ b/config/feed.php
@@ -21,6 +21,24 @@ return [
 
             'title' => env('FEED_TITLE', 'Post feed title'),
         ],
+        'custom' => [
+            /*
+             * Here you can specify which class and method will return
+             * the items that should appear in the feed. For example:
+             * 'App\Model@getAllFeedItems'
+             *
+             * You can also pass an argument to that method:
+             * ['App\Model@getAllFeedItems', 'argument']
+             */
+            'items' => 'App\Category@getFeedItems',
+
+            /*
+             * The feed will be available on this url.
+             */
+            'url' => env('CUSTOM_FEED_URL', 'custom.rss'),
+
+            'title' => env('CUSTOM_FEED_TITLE', 'Custom post feed title'),
+        ],
     ],
 
 ];

--- a/database/seeds/SettingSeeder.php
+++ b/database/seeds/SettingSeeder.php
@@ -284,7 +284,15 @@ class SettingSeeder extends Seeder
             'hidden' => '0',
         ];
 
-
+        $settings[] = [
+            'code' => 'rss.customFeedCategories',
+            'type' => 'ARRAY',
+            'label' => __("Custom RSS feed categories"),
+            'description' => __("Custom categories to generate a RSS feed for."),
+            'value' => '',
+            'category' => 'rss',
+            'hidden' => '0',
+        ];
 
         foreach ($settings as $setting) {
             try {

--- a/routes/web.php
+++ b/routes/web.php
@@ -108,8 +108,8 @@ Route::get('sitemap.xml', function() {
 
 if ($customClasses = App\Setting::get('custom.routeClasses')) {
     // dd(json_decode($customClasses));
-    if (is_array(json_decode($customClasses))) {
-        foreach (json_decode($customClasses) as $class) {
+    if (is_array($customClasses)) {
+        foreach ($customClasses as $class) {
             if (!empty($class)) {
                 $file = "../app/" . $class . ".php";
                 $class = 'App\\' . $class;


### PR DESCRIPTION
Create a custom RSS feed based on a set number of categories.

It adds a new Setting to set things up. Add one category on each line to have the published posts in that category appear on the RSS feed @ '/custom.rss'.

You can set its URL and Title using two new values in the .env file:

CUSTOM_FEED_URL
CUSTOM_FEED_TITLE

This commit requires the following Artisan commands:

php artisan db:seed
php artisan cache:clear