### PR TITLE
Bugfix: catch incorrectly formatted setting

### DIFF
--- a/app/Category.php
+++ b/app/Category.php
@@ -39,7 +39,12 @@ class Category extends CacheModel
     public static function getFeedItems()
     {
         $posts = collect();
+        $categories = Setting::get('rss.customFeedCategories');
 
+        if (!is_array($categories)) {
+            return $posts;
+        }
+        
         foreach (Setting::get('rss.customFeedCategories') as $c) {
             $category = Category::whereSlug($c)->first();
 


### PR DESCRIPTION
If the setting rss.customFeedCategories would not be an array, an exception would occur.

Not any more ;)