### PR TITLE
## 1.7.2 (2020-06-02)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,12 +19,19 @@ class AppServiceProvider extends ServiceProvider
         Schema::defaultStringLength(191);
 
         Blade::directive('google', function () {
-            if (Setting::get('analytics.enabled') && auth()->guest()) {   
+            $html = "";
+
+            if (!auth()->guest()) {
+                return "<?php echo \"<!-- Authorised users don't count towards analytics. -->\"; ?>";
+            }
+
+            if (Setting::get('analytics.enabled')) {   
+                $html = "<!-- Google tracking code goes here -->";
+
                 $trackingcode = Setting::get('analytics.trackingID');
 
                 if ($trackingcode !== null) {
-            
-                    $html = "<!-- Global site tag (gtag.js) - Google Analytics -->
+                    $html .= "<!-- Global site tag (gtag.js) - Google Analytics -->
                     <script async src=\'https://www.googletagmanager.com/gtag/js?id=".$trackingcode."\'></script>
                     <script>
                     window.dataLayer = window.dataLayer || [];
@@ -36,7 +43,11 @@ class AppServiceProvider extends ServiceProvider
 
                     return "<?php echo '$html'; ?>";
                 }
+
+                $html .= "<!-- At least it would, if someone had set a tracking code... -->";
             }
+
+            return "<?php echo '$html'; ?>";
         });
     }
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@
 - On Media index page, style images
 - On Menu admin page, split pages and posts & provide visual feedback for published status
 
+## 1.7.2 (2020-06-02)
+
+- Fixed: The @google directive didn't show information correctly. Do a php artisan view:clear to apply this fix.
+- Fixed: Adds slashes to the articleBody in the BlogPosting schema in core.post.show. Apply in your own templates too.
+
 ## 1.7.1 (2020-04-26)
 
 - Changed: Laravel/framework (v7.2.1 => 7.8.1)

--- a/resources/views/core/layout/app.blade.php
+++ b/resources/views/core/layout/app.blade.php
@@ -200,7 +200,7 @@
                     <div class="px-8">
                         <h3 class="font-bold text-gray-900">About</h3>
                         <p class="py-4 text-gray-600 text-sm">
-                            @lang('Current version'): 1.7.1 (2020-04-26)
+                            @lang('Current version'): 1.7.2 (2020-06-02)
                         </p>
                     </div>
                 </div>

--- a/resources/views/core/post/show.blade.php
+++ b/resources/views/core/post/show.blade.php
@@ -50,7 +50,7 @@
         @if ($post->categories->count() > 0)
 		    "articleSection": "{{ $post->categories->first()->name }}",
         @endif
-		"articleBody": "{!! strip_tags($post->body) !!}"
+		"articleBody": "{!! addslashes(strip_tags($post->body)) !!}"
 	}
 </script>
 @endsection


### PR DESCRIPTION
- Fixed: The @google directive didn't show information correctly. Do a php artisan view:clear to apply this fix.
- Fixed: Adds slashes to the articleBody in the BlogPosting schema in core.post.show. Apply in your own templates too.