### PR TITLE
## 1.7.2.1 (2020-06-02)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 ## 1.7.2 (2020-06-02)
 
 - Fixed: The @google directive didn't show information correctly. Do a php artisan view:clear to apply this fix.
-- Fixed: Adds slashes to the articleBody in the BlogPosting schema in core.post.show. Apply in your own templates too.
+- Fixed: Adds slashes to the articleBody double quotes in the BlogPosting schema in core.post.show. Apply in your own templates too.
 
 ## 1.7.1 (2020-04-26)
 

--- a/resources/views/core/post/show.blade.php
+++ b/resources/views/core/post/show.blade.php
@@ -50,7 +50,7 @@
         @if ($post->categories->count() > 0)
 		    "articleSection": "{{ $post->categories->first()->name }}",
         @endif
-		"articleBody": "{!! addslashes(strip_tags($post->body)) !!}"
+		"articleBody": "{!! str_replace('"', '\"', strip_tags($post->body)) !!}"
 	}
 </script>
 @endsection


### PR DESCRIPTION
- Fixed: Adds slashes to the articleBody double quotes in the BlogPosting schema in core.post.show. Apply in your own templates too.

This is a hotfix for 1.7.2, where addslashes was used. this also escaped single quotes, which made the post uncrawlable for Google.